### PR TITLE
add histogram section

### DIFF
--- a/app/routes/histogram.py
+++ b/app/routes/histogram.py
@@ -1,0 +1,66 @@
+import io
+import base64
+import os
+import matplotlib.pyplot as plt
+import numpy as np
+from fastapi import APIRouter, Request, Form
+from fastapi.responses import HTMLResponse
+from PIL import Image
+
+from app.config import Configuration
+from app.utils import list_images
+
+# Declare the router.
+router = APIRouter()
+
+def generate_histogram(image_path: str) -> str:
+    """
+    Generate a simple grayscale histogram for the given image.
+    The image is converted to grayscale and a filled histogram is plotted.
+    Returns the plot as a base64 encoded PNG image.
+    """
+    # Open image in grayscale.
+    img = Image.open(image_path).convert("L")
+    np_img = np.array(img)
+    # Compute the histogram with 256 bins.
+    hist, bins = np.histogram(np_img.flatten(), bins=256, range=[0, 256])
+    
+    # Create the plot.
+    plt.figure(figsize=(8, 4))
+    plt.plot(bins[:-1], hist, color='blue', linewidth=2)
+    plt.fill_between(bins[:-1], hist, color='lightblue', alpha=0.5)
+    plt.xlabel("Pixel Intensity")
+    plt.ylabel("Frequency")
+    plt.title("Image Histogram")
+    plt.tight_layout()
+    
+    # Save the plot to a buffer.
+    buf = io.BytesIO()
+    plt.savefig(buf, format='png')
+    plt.close()
+    buf.seek(0)
+    
+    # Return the image as base64.
+    return base64.b64encode(buf.read()).decode("utf-8")
+
+@router.get("/select", response_class=HTMLResponse)
+def get_histogram_form(request: Request):
+    """
+    Render a form for selecting an image to generate a histogram.
+    """
+    return request.app.state.templates.TemplateResponse(
+        "histogram_select.html",
+        {"request": request, "images": list_images()}
+    )
+
+@router.post("/select", response_class=HTMLResponse)
+async def show_histogram(request: Request, image_id: str = Form(...)):
+    """
+    Process the selected image and display its histogram.
+    """
+    image_path = os.path.join(Configuration().image_folder_path, image_id)
+    histogram_img = generate_histogram(image_path)
+    return request.app.state.templates.TemplateResponse(
+        "histogram_output.html",
+        {"request": request, "image_id": image_id, "histogram_img": histogram_img}
+    )

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -2,23 +2,21 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Image classification</title>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
+    <title>Image Classification</title>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
     <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0"></script>
-    <link rel="shortcut icon" href="static/favicon.ico">
+    <!-- Use absolute path for favicon -->
+    <link rel="shortcut icon" href="/static/favicon.ico">
 </head>
 <body>
-
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <div class="container">
-
         <a class="navbar-brand" href="/">Image Classification</a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
                 aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
-
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <ul class="navbar-nav mr-auto">
                 <li class="nav-item active">
@@ -27,31 +25,30 @@
                 <li class="nav-item">
                     <a class="nav-link" href="/classifications">Try it out!</a>
                 </li>
-                <!-- New Upload Image link -->
                 <li class="nav-item">
-                    <a class="nav-link" href="/classifications/upload"> Try with uploaded image Image</a>
+                    <a class="nav-link" href="/classifications/upload">Try with uploaded image</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/histogram/select">Histogram</a>
                 </li>
             </ul>
         </div>
     </div>
 </nav>
-
 <div class="container mt-4">
     <!-- Display errors if any -->
     <div class="text-danger font-weight-bold">
         {% if errors %}
           <ul>
-          {% for error in errors %}
+            {% for error in errors %}
               <li>{{ error }}</li>
-          {% endfor %}
+            {% endfor %}
           </ul>
         {% endif %}
     </div>
-
     {% block content %}
     {% endblock %}
 </div>
-
 <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
 </body>

--- a/app/templates/classification_output.html
+++ b/app/templates/classification_output.html
@@ -3,7 +3,6 @@
 {% block content %}
     <style>
         .large-front-thumbnail {
-            position: relative;
             max-width: 100%;
             height: auto;
             display: block;
@@ -13,9 +12,7 @@
     <div class="row">
         <div class="col-md-6">
             <div class="card mb-4">
-                <img class="large-front-thumbnail"
-                     src="/static/imagenet_subset/{{ image_id }}"
-                     alt="{{ image_id }}"/>
+                <img class="large-front-thumbnail" src="/static/imagenet_subset/{{ image_id }}" alt="{{ image_id }}"/>
             </div>
         </div>
         <div class="col-md-6">

--- a/app/templates/histogram_output.html
+++ b/app/templates/histogram_output.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>Image Histogram</h1>
+    <div class="row">
+        <div class="col-md-6">
+            <h3>Original Image</h3>
+            <img src="/static/imagenet_subset/{{ image_id }}" alt="{{ image_id }}" class="img-fluid">
+        </div>
+        <div class="col-md-6">
+            <h3>Histogram</h3>
+            <img src="data:image/png;base64,{{ histogram_img }}" alt="Histogram" class="img-fluid">
+        </div>
+    </div>
+    <a href="/histogram/select" class="btn btn-primary mt-3">Back</a>
+{% endblock %}

--- a/app/templates/histogram_select.html
+++ b/app/templates/histogram_select.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>Select Image for Histogram</h1>
+    <form action="/histogram/select" method="post" novalidate>
+        <label for="image_id">Image:</label>
+        <select id="image_id" name="image_id">
+            {% for image in images %}
+                <option value="{{ image }}">{{ image }}</option>
+            {% endfor %}
+        </select>
+        <input type="submit" value="Submit">
+    </form>
+{% endblock %}


### PR DESCRIPTION
Histogram Feature:

- Added GET/POST endpoints at /histogram/select to let users select an image and view its histogram.
- New templates histogram_select.html and histogram_output.html render the form and display the histogram.
- Generates a simple grayscale histogram using matplotlib and returns it as a base64-encoded PNG.

Navigation & Integration:

- Added a new link in base.html for the histogram page.
- Preserved existing functionality.